### PR TITLE
Add "psalm.disableDefinision"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ composer require --dev vimeo/psalm
 
 - `psalm.enable`: Enable coc-psalm extension, default: `true`
 - `psalm.disableCompletion`: Disable completion only, default: `false`
+- `psalm.disableDefinition`: Disable definition only, default: `false`
 - `psalm.phpExecutablePath`: Optional, defaults to searching for "php". The path to a PHP 7.0+ executable to use to execute the Psalm server. The PHP 7.0+ installation should preferably include and enable the PHP module `pcntl`. (Modifying requires restart), default: `null`
 - `psalm.phpExecutableArgs`: Optional (Advanced), default is '-dxdebug.remote_autostart=0 -dxdebug.remote_enable=0 -dxdebug_profiler_enable=0'.  Additional PHP executable CLI arguments to use, default: `["-dxdebug.remote_autostart=0", "-dxdebug.remote_enable=0", "-dxdebug_profiler_enable=0"]`
 - `psalm.psalmScriptPath`: Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm-language-server. (Modifying requires restart), default: `null`

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
           "default": false,
           "description": "Disable completion only."
         },
+        "psalm.disableDefinition": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable definition only."
+        },
         "psalm.phpExecutablePath": {
           "type": [
             "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,19 @@
 import {
+  CancellationToken,
+  commands,
+  Diagnostic,
+  DocumentSelector,
   ExtensionContext,
-  window,
+  HandleDiagnosticsSignature,
   LanguageClient,
   LanguageClientOptions,
-  StreamInfo,
-  DocumentSelector,
-  workspace,
-  Diagnostic,
-  HandleDiagnosticsSignature,
-  commands,
   languages,
+  Position,
+  ProvideDefinitionSignature,
+  StreamInfo,
+  TextDocument,
+  window,
+  workspace,
 } from 'coc.nvim';
 
 import * as path from 'path';
@@ -103,6 +107,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const unusedVariableDetection = conf.get<boolean>('unusedVariableDetection') || false;
   const enableDebugLog = true; // conf.get<boolean>('enableDebugLog') || false;
   const disableCompletion = conf.get<boolean>('disableCompletion') || false;
+  const disableDefinition = conf.get<boolean>('disableDefinition') || false;
 
   const analyzedFileExtensions: undefined | string[] | DocumentSelector = conf.get<string[] | DocumentSelector>(
     'analyzedFileExtensions'
@@ -320,6 +325,17 @@ export async function activate(context: ExtensionContext): Promise<void> {
       handleDiagnostics: (uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) => {
         diagnostics = diagnostics.filter((o) => (o.code = JSON.stringify(o.code, ['value']).replace('value', 'issue')));
         next(uri, diagnostics);
+      },
+      provideDefinition: async (
+        document: TextDocument,
+        position: Position,
+        token: CancellationToken,
+        next: ProvideDefinitionSignature
+      ) => {
+        if (disableDefinition) return;
+
+        const def = await next(document, position, token);
+        return def;
       },
     },
   };


### PR DESCRIPTION
If you are using two language servers or coc extensions, you may want to disable the "definition" of only one of them. (They both provide "definition").

In some cases, if both "definition" are provided, there will be duplicates jump list.

For example, `intelephense(coc-intelephense)` + `psalm-language-server(coc-psalm)`.

----

I got the idea to add the feature from the "coc.nvim discussions". thanks @fannheyward

- <https://github.com/neoclide/coc.nvim/discussions/3030#discussioncomment-607667>
