### PR TITLE
feat(option): add "psalm.psalmScriptExtraArgs" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ composer require --dev vimeo/psalm
 - `psalm.phpExecutablePath`: Optional, defaults to searching for "php". The path to a PHP 7.0+ executable to use to execute the Psalm server. The PHP 7.0+ installation should preferably include and enable the PHP module `pcntl`. (Modifying requires restart), default: `null`
 - `psalm.phpExecutableArgs`: Optional (Advanced), default is '-dxdebug.remote_autostart=0 -dxdebug.remote_enable=0 -dxdebug_profiler_enable=0'.  Additional PHP executable CLI arguments to use, default: `["-dxdebug.remote_autostart=0", "-dxdebug.remote_enable=0", "-dxdebug_profiler_enable=0"]`
 - `psalm.psalmScriptPath`: Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm-language-server. (Modifying requires restart), default: `null`
+- `psalm.psalmScriptExtraArgs`: Optional (Advanced). Additional arguments to the Psalm language server. (Modifying requires restart), default: `[]`
 - `psalm.psalmClientScriptPath`: Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm. (Modifying requires restart), default: `null`
 - `psalm.enableUseIniDefaults`: Enable this to use PHP-provided ini defaults for memory and error display. (Modifying requires restart), default: `false`
 - `psalm.enableDebugLog`: Enable this to print messages, default: `false`

--- a/package.json
+++ b/package.json
@@ -83,6 +83,14 @@
           "default": null,
           "description": "Optional (Advanced). If provided, this overrides the Psalm script to use, e.g. vendor/bin/psalm-language-server. (Modifying requires restart)"
         },
+        "psalm.psalmScriptExtraArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Optional (Advanced). Additional arguments to the Psalm language server. (Modifying requires restart)"
+        },
         "psalm.psalmClientScriptPath": {
           "type": [
             "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const enableDebugLog = true; // conf.get<boolean>('enableDebugLog') || false;
   const disableCompletion = conf.get<boolean>('disableCompletion') || false;
   const disableDefinition = conf.get<boolean>('disableDefinition') || false;
+  const psalmScriptExtraArgs = conf.get<string[]>('psalmScriptExtraArgs', []) || [];
 
   const analyzedFileExtensions: undefined | string[] | DocumentSelector = conf.get<string[] | DocumentSelector>(
     'analyzedFileExtensions'
@@ -228,6 +229,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     '--language-server'
   );
   const psalmScriptArgs = psalmHasLanguageServerOption ? ['--language-server'] : [];
+  if (psalmScriptExtraArgs) {
+    if (Array.isArray(psalmScriptExtraArgs)) {
+      psalmScriptArgs.unshift(...psalmScriptExtraArgs);
+    }
+  }
   const psalmHasExtendedDiagnosticCodes: boolean = await checkPsalmLanguageServerHasOption(
     phpExecutablePath,
     phpExecutableArgs,


### PR DESCRIPTION
This is the "psalm.psalmScriptArgs" setting added by "psalm-vscode-plugin". In "coc-psalm", rename the configuration to `psalm.psalmScriptExtraArgs` and add it.

Since "coc-psalm" has added its own options such as `psalm.disableCompletion` and `psalm.disableDefinition`, there is no need to add any settings in `psalm.psalmScriptExtraArgs` at this time, but we will add them just in case. 

**REF**:

- <https://github.com/psalm/psalm-vscode-plugin/pull/123>