### PR TITLE
Replace activationEvents with globbed paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install `psalm` in your project.
 composer require --dev vimeo/psalm
 ```
 
-**Requires**: `psalm.xml` or `psalm.xml.dist` file is required in the project root as a condition for starting "coc-psalm".
+**Required:** The project must contain a `psalm.xml` or `psalm.xml.dist` file as a condition for starting "coc-psalm".
 
 ```sh
 ./vendor/bin/psalm --init

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "semi": true
   },
   "activationEvents": [
-    "workspaceContains:psalm.xml",
-    "workspaceContains:psalm.xml.dist"
+    "workspaceContains:**/psalm.xml",
+    "workspaceContains:**/psalm.xml.dist"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Makes it so coc will search for a **psalm.xml** or **psalm.xml.dist** anywhere in the project rather than only the root when it decides if it should load the plugin or not, and updates wording in the readme to remove the implied project root requirement.

Fixes #16 